### PR TITLE
Remove usage of mysqld --init-file option

### DIFF
--- a/galera.yml
+++ b/galera.yml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: mysql
-        image: adfinissygroup/k8s-mariadb-galera-centos:v001
+        image: adfinissygroup/k8s-mariadb-galera-centos:v002
         imagePullPolicy: Always
         ports:
         - containerPort: 3306

--- a/k8s-mariadb-galera-centos/Dockerfile
+++ b/k8s-mariadb-galera-centos/Dockerfile
@@ -6,7 +6,7 @@ LABEL io.k8s.description="MariaDB is a multi-user, multi-threaded SQL database s
       io.openshift.tags="database,mysql,mariadb10,rh-mariadb10"
 EXPOSE 3306/tcp
 
-ADD root/etc/yum.repos.d/mariadb.repo /etc/yum.repos.d/
+COPY root/etc/yum.repos.d/mariadb.repo /etc/yum.repos.d/
 
 RUN rpm --import https://yum.mariadb.org/RPM-GPG-KEY-MariaDB && \
     yum install -y \
@@ -22,8 +22,8 @@ RUN rpm --import https://yum.mariadb.org/RPM-GPG-KEY-MariaDB && \
       policycoreutils && \
     yum clean all
 
-ADD root /
-RUN  /usr/libexec/container-setup.sh
+COPY root /
+RUN /usr/libexec/container-setup.sh
 
 VOLUME ["/var/lib/mysql"]
 USER 27

--- a/k8s-mariadb-galera-centos/Makefile
+++ b/k8s-mariadb-galera-centos/Makefile
@@ -1,5 +1,5 @@
 IMAGE_NAME=adfinissygroup/k8s-mariadb-galera-centos
-IMAGE_VERSION=v001
+IMAGE_VERSION=v002
 LOCAL_REGISTRY=localhost:5000
 
 image:

--- a/k8s-mariadb-galera-centos/root/usr/bin/container-entrypoint.sh
+++ b/k8s-mariadb-galera-centos/root/usr/bin/container-entrypoint.sh
@@ -10,7 +10,6 @@ set -x
 # Locations
 CONTAINER_SCRIPTS_DIR="/usr/share/container-scripts/mysql"
 EXTRA_DEFAULTS_FILE="/etc/my.cnf.d/galera.cnf"
-FIRST_TIME_SQL="/tmp/mysql-first-time.sql"
 MYSQLD_FLAGS=""
 
 
@@ -33,8 +32,7 @@ fi
 # We assume that mysql needs to be setup if this directory is not present
 if [ ! -d "/var/lib/mysql/mysql" ]; then
 	echo "Configure first time mysql"
-	${CONTAINER_SCRIPTS_DIR}/configure-mysql.sh "${FIRST_TIME_SQL}"
-	MYSQLD_FLAGS+="--init-file=${FIRST_TIME_SQL} "
+	${CONTAINER_SCRIPTS_DIR}/configure-mysql.sh
 fi
 
 

--- a/k8s-mariadb-galera-centos/root/usr/share/container-scripts/mysql/configure-mysql.sh
+++ b/k8s-mariadb-galera-centos/root/usr/share/container-scripts/mysql/configure-mysql.sh
@@ -4,25 +4,36 @@
 # openshift-mariadb-galera: mysql setup script
 #
 
-set -e
-set -x
-
-if [ -z $1 ]; then
-  FIRST_TIME_SQL="/tmp/mysql-first-time.sql"
-else
-  FIRST_TIME_SQL="$1"
-fi
-
+set -eox pipefail
 
 echo 'Running mysql_install_db ...'
 mysql_install_db --datadir=/var/lib/mysql
 echo 'Finished mysql_install_db'
 
-# These statements _must_ be on individual lines, and _must_ end with
-# semicolons (no line breaks or comments are permitted).
-# TODO proper SQL escaping on ALL the things D:
+mysqld --skip-networking --socket=/var/lib/mysql/mysql-init.sock --wsrep_on=OFF &
+pid="$!"
 
-cat > "$FIRST_TIME_SQL" <<-EOSQL
+mysql=( mysql --protocol=socket -uroot -hlocalhost --socket=/var/lib/mysql/mysql-init.sock )
+
+for i in {30..0}; do
+  if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then
+    break
+  fi
+  echo 'MySQL init process in progress...'
+  sleep 1
+done
+if [ "$i" = 0 ]; then
+  echo >&2 'MySQL init process failed.'
+  exit 1
+fi
+
+if [ -z "$MYSQL_INITDB_SKIP_TZINFO" ]; then
+	# sed is for https://bugs.mysql.com/bug.php?id=20545
+	mysql_tzinfo_to_sql /usr/share/zoneinfo | sed 's/Local time zone must be set--see zic manual page/FCTY/' | "${mysql[@]}" mysql
+fi
+
+# add MariaDB root user
+"${mysql[@]}" <<-EOSQL
 -- What's done in this file shouldn't be replicated
 --  or products like mysql-fabric won't work
 SET @@SESSION.SQL_LOG_BIN=0;
@@ -31,31 +42,42 @@ DELETE FROM mysql.user ;
 CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
 GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
 DROP DATABASE IF EXISTS test ;
-CREATE USER 'xtrabackup_sst'@'localhost' IDENTIFIED BY 'xtrabackup_sst' ;
-GRANT RELOAD, LOCK TABLES, REPLICATION CLIENT ON *.* TO 'xtrabackup_sst'@'localhost' ;
-
-
-CREATE USER 'readinessProbe'@'127.0.0.1' IDENTIFIED BY 'readinessProbe';
+FLUSH PRIVILEGES ;
 EOSQL
 
+# add root password for subsequent calls to mysql
+if [ ! -z "$MYSQL_ROOT_PASSWORD" ]; then
+	mysql+=( -p"${MYSQL_ROOT_PASSWORD}" )
+fi
+
+# add users require for Galera
+# TODO: make them somehow configurable
+"${mysql[@]}" <<-EOSQL
+CREATE USER 'xtrabackup_sst'@'localhost' IDENTIFIED BY 'xtrabackup_sst' ;
+GRANT RELOAD, LOCK TABLES, REPLICATION CLIENT ON *.* TO 'xtrabackup_sst'@'localhost' ;
+CREATE USER 'readinessProbe'@'localhost' IDENTIFIED BY 'readinessProbe';
+EOSQL
 
 if [ "$MYSQL_DATABASE" ]; then
-  echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" >> "$FIRST_TIME_SQL"
+	echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" | "${mysql[@]}"
+	mysql+=( "$MYSQL_DATABASE" )
 fi
 
 if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
-  echo "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;" >> "$FIRST_TIME_SQL"
-  echo "CREATE USER '$MYSQL_USER'@'localhost' IDENTIFIED BY '$MYSQL_PASSWORD' ;" >> "$FIRST_TIME_SQL"
+	echo "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;" | "${mysql[@]}"
+
+	if [ "$MYSQL_DATABASE" ]; then
+		echo "GRANT ALL ON \`$MYSQL_DATABASE\`.* TO '$MYSQL_USER'@'%' ;" | "${mysql[@]}"
+	fi
+
+	echo 'FLUSH PRIVILEGES ;' | "${mysql[@]}"
 fi
 
-if [ "$MYSQL_USER" -a ! "$MYSQL_PASSWORD" ]; then
-  echo "CREATE USER '$MYSQL_USER'@'%'  ;"         >> "$FIRST_TIME_SQL"
-  echo "CREATE USER '$MYSQL_USER'@'localhost'  ;" >> "$FIRST_TIME_SQL"
+if ! kill -s TERM "$pid" || ! wait "$pid"; then
+	echo >&2 'MySQL init process failed.'
+	exit 1
 fi
 
-if [ "$MYSQL_USER" -a  "$MYSQL_DATABASE"  ]; then
-  echo "GRANT ALL ON \`$MYSQL_DATABASE\`.* TO '$MYSQL_USER'@'%' ;" >> "$FIRST_TIME_SQL"
-  echo "GRANT ALL ON \`$MYSQL_DATABASE\`.* TO '$MYSQL_USER'@'localhost' ;" >> "$FIRST_TIME_SQL"
-fi
-
-echo 'FLUSH PRIVILEGES ;' >> "$FIRST_TIME_SQL"
+echo
+echo 'MySQL init process done. Ready for start up.'
+echo

--- a/k8s-mariadb-galera-centos/root/usr/share/container-scripts/mysql/readiness-probe.sh
+++ b/k8s-mariadb-galera-centos/root/usr/share/container-scripts/mysql/readiness-probe.sh
@@ -6,7 +6,7 @@
 
 MYSQL_USER="readinessProbe"
 MYSQL_PASS="readinessProbe"
-MYSQL_HOST="127.0.0.1"
+MYSQL_HOST="localhost"
 
 mysql -u${MYSQL_USER} -p${MYSQL_PASS} -h${MYSQL_HOST} -e"SHOW DATABASES;"
 

--- a/mariadb-galera-ephemeral-template.yml
+++ b/mariadb-galera-ephemeral-template.yml
@@ -66,7 +66,7 @@ objects:
       spec:
         containers:
         - name: "${GALERA_PETSET_NAME}"
-          image: adfinissygroup/k8s-mariadb-galera-centos:v001
+          image: adfinissygroup/k8s-mariadb-galera-centos:v002
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 3306

--- a/mariadb-galera-persistent-template.yml
+++ b/mariadb-galera-persistent-template.yml
@@ -75,7 +75,7 @@ objects:
       spec:
         containers:
         - name: "${GALERA_PETSET_NAME}"
-          image: adfinissygroup/k8s-mariadb-galera-centos:v001
+          image: adfinissygroup/k8s-mariadb-galera-centos:v002
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 3306


### PR DESCRIPTION
Configuring users with the --init-file corrupted the mysql.user table
and broke scaling up after a scale down. We've now changed to an
approach similar to the mariadb Docker image, and increased the version
of the Docker image to v002.

Fixes #4 