### PR TITLE
add ignore_db_dirs=lost+found as default

### DIFF
--- a/k8s-mariadb-galera-centos/root/etc/my.cnf.d/server.cnf
+++ b/k8s-mariadb-galera-centos/root/etc/my.cnf.d/server.cnf
@@ -5,6 +5,7 @@ bind-address                      = 0.0.0.0
 # this is only for the mysqld standalone daemon
 [mysqld]
 datadir = /var/lib/mysql
+ignore_db_dirs=lost+found
 
 #
 # * Galera-related settings


### PR DESCRIPTION
Implemented the changes to the default MariaDB configuration according to #10 