### PR TITLE
Move mysqld-socket from /var/lib/mysql to /var/run/mysql

### DIFF
--- a/galera.yml
+++ b/galera.yml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: mysql
-        image: adfinissygroup/k8s-mariadb-galera-centos:v002
+        image: adfinissygroup/k8s-mariadb-galera-centos:v003
         imagePullPolicy: Always
         ports:
         - containerPort: 3306
@@ -50,6 +50,7 @@ spec:
         volumeMounts:
         - name: datadir
           mountPath: /var/lib/mysql
+          subPath: data
         env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/galera_k8s_v1.5.yml
+++ b/galera_k8s_v1.5.yml
@@ -30,7 +30,7 @@ spec:
     spec:
       containers:
       - name: mysql
-        image: adfinissygroup/k8s-mariadb-galera-centos:v002
+        image: adfinissygroup/k8s-mariadb-galera-centos:v003
         imagePullPolicy: Always
         ports:
         - containerPort: 3306
@@ -50,6 +50,7 @@ spec:
         volumeMounts:
         - name: datadir
           mountPath: /var/lib/mysql
+          subPath: data
         env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/k8s-mariadb-galera-centos/Makefile
+++ b/k8s-mariadb-galera-centos/Makefile
@@ -1,5 +1,5 @@
 IMAGE_NAME=adfinissygroup/k8s-mariadb-galera-centos
-IMAGE_VERSION=v002
+IMAGE_VERSION=v003
 LOCAL_REGISTRY=localhost:5000
 
 image:

--- a/k8s-mariadb-galera-centos/root/etc/my.cnf.d/client.cnf
+++ b/k8s-mariadb-galera-centos/root/etc/my.cnf.d/client.cnf
@@ -1,0 +1,12 @@
+#
+# These two groups are read by the client library
+# Use it for options that affect all clients, but not the server
+#
+
+[client]
+socket = /var/run/mysql/mysql.sock
+
+# This group is not read by mysql client library,
+# If you use the same .cnf file for MySQL and MariaDB,
+# use it for MariaDB-only client options
+[client-mariadb]

--- a/k8s-mariadb-galera-centos/root/etc/my.cnf.d/server.cnf
+++ b/k8s-mariadb-galera-centos/root/etc/my.cnf.d/server.cnf
@@ -6,6 +6,7 @@ bind-address                      = 0.0.0.0
 [mysqld]
 datadir = /var/lib/mysql
 ignore_db_dirs=lost+found
+socket = /var/run/mysql/mysql.sock
 
 #
 # * Galera-related settings

--- a/k8s-mariadb-galera-centos/root/usr/libexec/container-setup.sh
+++ b/k8s-mariadb-galera-centos/root/usr/libexec/container-setup.sh
@@ -8,7 +8,7 @@
 # Locations
 MYSQL_CONFIG_DIR="/etc/my.cnf.d"
 MYSQL_DATA_DIR="/var/lib/mysql"
-
+MYSQL_RUN_DIR="/var/run/mysql"
 
 # Fix data directory permissions
 rm -rf ${MYSQL_DATA_DIR}
@@ -23,3 +23,9 @@ mkdir -p ${MYSQL_CONFIG_DIR}
 chown -R 27:0 ${MYSQL_CONFIG_DIR}
 chmod -R g+w ${MYSQL_CONFIG_DIR}
 restorecon -R ${MYSQL_CONFIG_DIR}
+
+# Create run directory
+mkdir -p ${MYSQL_RUN_DIR}
+chown -R 27:0 ${MYSQL_RUN_DIR}
+chmod -R g+w ${MYSQL_RUN_DIR}
+restorecon -R ${MYSQL_RUN_DIR}

--- a/k8s-mariadb-galera-centos/root/usr/share/container-scripts/mysql/configure-mysql.sh
+++ b/k8s-mariadb-galera-centos/root/usr/share/container-scripts/mysql/configure-mysql.sh
@@ -10,10 +10,10 @@ echo 'Running mysql_install_db ...'
 mysql_install_db --datadir=/var/lib/mysql
 echo 'Finished mysql_install_db'
 
-mysqld --skip-networking --socket=/var/lib/mysql/mysql-init.sock --wsrep_on=OFF &
+mysqld --skip-networking --socket=/var/run/mysql/mysql-init.sock --wsrep_on=OFF &
 pid="$!"
 
-mysql=( mysql --protocol=socket -uroot -hlocalhost --socket=/var/lib/mysql/mysql-init.sock )
+mysql=( mysql --protocol=socket -uroot -hlocalhost --socket=/var/run/mysql/mysql-init.sock )
 
 for i in {30..0}; do
   if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then

--- a/k8s-mariadb-galera-centos/root/usr/share/container-scripts/mysql/readiness-probe.sh
+++ b/k8s-mariadb-galera-centos/root/usr/share/container-scripts/mysql/readiness-probe.sh
@@ -8,7 +8,7 @@ MYSQL_USER="readinessProbe"
 MYSQL_PASS="readinessProbe"
 MYSQL_HOST="localhost"
 
-mysql -u${MYSQL_USER} -p${MYSQL_PASS} -h${MYSQL_HOST} -e"SHOW DATABASES;"
+mysql --protocol=socket --socket=/var/run/mysql/mysql.sock -u${MYSQL_USER} -p${MYSQL_PASS} -h${MYSQL_HOST} -e"SHOW DATABASES;"
 
 if [ $? -ne 0 ]; then
   exit 1

--- a/mariadb-galera-ephemeral-template.yml
+++ b/mariadb-galera-ephemeral-template.yml
@@ -66,7 +66,7 @@ objects:
       spec:
         containers:
         - name: "${GALERA_PETSET_NAME}"
-          image: adfinissygroup/k8s-mariadb-galera-centos:v002
+          image: adfinissygroup/k8s-mariadb-galera-centos:v003
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 3306

--- a/mariadb-galera-persistent-template.yml
+++ b/mariadb-galera-persistent-template.yml
@@ -75,7 +75,7 @@ objects:
       spec:
         containers:
         - name: "${GALERA_PETSET_NAME}"
-          image: adfinissygroup/k8s-mariadb-galera-centos:v002
+          image: adfinissygroup/k8s-mariadb-galera-centos:v003
           imagePullPolicy: IfNotPresent
           ports:
           - containerPort: 3306
@@ -95,6 +95,7 @@ objects:
           volumeMounts:
           - name: "${VOLUME_PV_NAME}"
             mountPath: /var/lib/mysql
+            subPath: data
           env:
             - name: POD_NAMESPACE
               valueFrom:


### PR DESCRIPTION
For supporting glusterfs PVs.
Also updated image version and added subPath for PV mounts