### PR TITLE
Add the required user security context for 1.6+ clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,11 @@ $ kubectl create -f galera-pv-host.yml
 $ kubectl create -f galera.yml
 ```
 
-For Kubernetes v1.5 the API endpoints have changed and you need to use
-the definition in `galera_k8s_v1.5/yml`.
+For Kubernetes v1.5 the API endpoints have changed you need to use the definition in `galera_k8s_v1.6.yml`.
 
 ```bash
 $ kubectl create -f galera-pv-host.yml
-$ kubectl create -f galera)k8s_v1.5.yml
+$ kubectl create -f galera_k8s_v1.6.yml
 ```
 
 ### Cleanup cluster

--- a/galera_k8s_v1.6.yml
+++ b/galera_k8s_v1.6.yml
@@ -28,10 +28,15 @@ spec:
       annotations:
         pod.alpha.kubernetes.io/initialized: "true"
     spec:
+      securityContext:
+        runAsUser: 27
+        fsGroup: 27
       containers:
       - name: mysql
         image: adfinissygroup/k8s-mariadb-galera-centos:v003
         imagePullPolicy: Always
+        securityContext:
+          runAsNonRoot: true
         ports:
         - containerPort: 3306
           name: mysql

--- a/k8s-mariadb-galera-centos/Dockerfile
+++ b/k8s-mariadb-galera-centos/Dockerfile
@@ -27,5 +27,5 @@ COPY root /
 RUN /usr/libexec/container-setup.sh
 
 VOLUME ["/var/lib/mysql"]
-USER 27
+USER 27:27
 ENTRYPOINT ["/usr/bin/container-entrypoint.sh"]


### PR DESCRIPTION
When testing with kubernetes 1.8 (should be 1.6+), get a permission denied with the `mkdir -p /var/lib/mysql/mysql` unless the correct user context is set.